### PR TITLE
Add a use:stable command, inverse of use:dev

### DIFF
--- a/Commands/ComposerConstraint.php
+++ b/Commands/ComposerConstraint.php
@@ -52,7 +52,7 @@ final class ComposerConstraint {
    *   '8.4.3 || ^8.5.3', it will be '8.4.x-dev || 8.5.x-dev'.
    */
   public function getCoreDev() {
-    return $this->getDev([$this, 'coreRangeToDev']);
+    return $this->mapRanges([$this, 'coreRangeToDev']);
   }
 
   /**
@@ -66,22 +66,19 @@ final class ComposerConstraint {
    *   '^1.3.0 || ^2.3.0', it will be '1.x-dev || 2.x-dev'.
    */
   public function getLightningDev() {
-    return $this->getDev([$this, 'lightningRangeToDev']);
+    return $this->mapRanges([$this, 'lightningRangeToDev']);
   }
 
   /**
-   * Returns the dev version of the constraint.
-   *
-   * In the dev version the constraint's ranges are replaced with the
-   * result of the callback.
+   * Returns the transformed constraint.
    *
    * @param callable $callback
    *   Transformation to apply to each range.
    *
    * @return string
-   *   Dev version.
+   *   Transformed constraint.
    */
-  private function getDev(callable $callback) {
+  public function mapRanges(callable $callback) {
     $ranges = $this->getRanges();
     $replace_pairs = [];
 

--- a/Commands/ReleaseHistoryClient.php
+++ b/Commands/ReleaseHistoryClient.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Acquia\Lightning\Commands;
+
+use GuzzleHttp\Client;
+
+/**
+ * Class to fetch release history information about Drupal projects.
+ */
+final class ReleaseHistoryClient {
+
+  /**
+   * The HTTP client.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  private $httpClient;
+
+  /**
+   * ReleaseHistoryClient constructor.
+   *
+   * @param \GuzzleHttp\Client $http_client
+   *   The HTTP client.
+   */
+  public function __construct(Client $http_client) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * Fetches the latest stable release of a project from Drupal.org.
+   *
+   * @param string $name
+   *   The name of the Drupal project (e.g. 'lightning_core').
+   * @param string $api_version
+   *   The API compatibility version (e.g. '8.x').
+   * @param string $range
+   *   The constraint range (e.g. '3.x-dev').
+   *
+   * @return string
+   *   The latest stable release (e.g. '3.2'), or empty string if not found.
+   */
+  public function getLatestStableRelease($name, $api_version, $range) {
+    $release_history = $this->getReleaseHistory($name, $api_version);
+
+    $prefix = "$api_version-";
+    $prefix_length = strlen($prefix);
+
+    // Remove the '.x-dev' suffix from range if present.
+    $suffix = '.x-dev';
+    $suffix_position = -strlen($suffix);
+
+    if (substr($range, $suffix_position) === $suffix) {
+      $range = substr($range, 0, $suffix_position);
+    }
+
+    // Releases are ordered from newest to oldest.
+    foreach ($release_history->releases->release as $release) {
+      $release_version = (string) $release->version;
+
+      // Remove the API version prefix from the release version if exists.
+      // For example, if the release version is '8.x-3.2', it will be '3.2'.
+      if (strncmp($release_version, $prefix, $prefix_length) === 0) {
+        $release_version = substr($release_version, $prefix_length);
+      }
+
+      if (strncmp($release_version, $range, strlen($range)) === 0) {
+        return $release_version;
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * Fetches a project's release history from Drupal.org.
+   *
+   * @param string $name
+   *   The name of the Drupal project (e.g. 'lightning_core').
+   * @param string $api_version
+   *   The API compatibility version (e.g. '8.x').
+   *
+   * @return \SimpleXMLElement
+   *   The parsed XML response.
+   */
+  private function getReleaseHistory($name, $api_version) {
+    $uri = "https://updates.drupal.org/release-history/$name/$api_version";
+    $data = $this->httpClient->get($uri)->getBody()->getContents();
+
+    return simplexml_load_string($data);
+  }
+
+}

--- a/Commands/ReleaseHistoryClient.php
+++ b/Commands/ReleaseHistoryClient.php
@@ -31,18 +31,16 @@ final class ReleaseHistoryClient {
    *
    * @param string $name
    *   The name of the Drupal project (e.g. 'lightning_core').
-   * @param string $api_version
-   *   The API compatibility version (e.g. '8.x').
    * @param string $range
    *   The constraint range (e.g. '3.x-dev').
    *
    * @return string
    *   The latest stable release (e.g. '3.2'), or empty string if not found.
    */
-  public function getLatestStableRelease($name, $api_version, $range) {
-    $release_history = $this->getReleaseHistory($name, $api_version);
+  public function getLatestStableRelease($name, $range) {
+    $release_history = $this->getReleaseHistory($name);
 
-    $prefix = "$api_version-";
+    $prefix = "8.x-";
     $prefix_length = strlen($prefix);
 
     // Remove the '.x-dev' suffix from range if present.
@@ -76,14 +74,12 @@ final class ReleaseHistoryClient {
    *
    * @param string $name
    *   The name of the Drupal project (e.g. 'lightning_core').
-   * @param string $api_version
-   *   The API compatibility version (e.g. '8.x').
    *
    * @return \SimpleXMLElement
    *   The parsed XML response.
    */
-  private function getReleaseHistory($name, $api_version) {
-    $uri = "https://updates.drupal.org/release-history/$name/$api_version";
+  private function getReleaseHistory($name) {
+    $uri = "https://updates.drupal.org/release-history/$name/8.x";
     $data = $this->httpClient->get($uri)->getBody()->getContents();
 
     return simplexml_load_string($data);

--- a/Commands/ReleaseHistoryClient.php
+++ b/Commands/ReleaseHistoryClient.php
@@ -40,28 +40,17 @@ final class ReleaseHistoryClient {
   public function getLatestStableRelease($name, $range) {
     $release_history = $this->getReleaseHistory($name);
 
-    $prefix = "8.x-";
-    $prefix_length = strlen($prefix);
-
     // Remove the '.x-dev' suffix from range if present.
-    $suffix = '.x-dev';
-    $suffix_position = -strlen($suffix);
-
-    if (substr($range, $suffix_position) === $suffix) {
-      $range = substr($range, 0, $suffix_position);
-    }
+    $range = preg_replace('#\.x-dev$#', '', $range);
+    $range_length = strlen($range);
 
     // Releases are ordered from newest to oldest.
     foreach ($release_history->releases->release as $release) {
       $release_version = (string) $release->version;
+      // Remove the '8.x-' prefix from release version if present.
+      $release_version = preg_replace('#^8\.x-#', '', $release_version);
 
-      // Remove the API version prefix from the release version if exists.
-      // For example, if the release version is '8.x-3.2', it will be '3.2'.
-      if (strncmp($release_version, $prefix, $prefix_length) === 0) {
-        $release_version = substr($release_version, $prefix_length);
-      }
-
-      if (strncmp($release_version, $range, strlen($range)) === 0) {
+      if (strncmp($release_version, $range, $range_length) === 0) {
         return $release_version;
       }
     }

--- a/Commands/RoboFile.php
+++ b/Commands/RoboFile.php
@@ -5,6 +5,7 @@ namespace Acquia\Lightning\Commands;
 use cebe\markdown\GithubMarkdown;
 use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\NestedArray;
+use GuzzleHttp\Client;
 use Robo\Tasks;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
@@ -637,6 +638,49 @@ class RoboFile extends Tasks
             {
                 $composer_constraint = new ComposerConstraint($constraint);
                 $task->dependency($package, $composer_constraint->getLightningDev());
+            }
+        }
+
+        return $task;
+    }
+
+    /**
+     * Switches all Composer dependencies to stable.
+     *
+     * @return \Robo\Task\Composer\RequireDependency
+     *   The task to execute.
+     */
+    public function useStable ()
+    {
+        $composer = file_get_contents('composer.json');
+        $composer = json_decode($composer, TRUE);
+
+        /** @var \Robo\Task\Composer\RequireDependency $task */
+        $task = $this->taskComposerRequire()->option('no-update');
+        $client = new ReleaseHistoryClient(new Client());
+
+        foreach ($composer['require'] as $package => $constraint)
+        {
+            if ($package === 'drupal/core')
+            {
+                $callback = function ($range) use ($client) {
+                    $release = $client->getLatestStableRelease('drupal', '8.x', $range);
+
+                    return $release ? "~$release" : $range;
+                };
+                $version = (new ComposerConstraint($constraint))->mapRanges($callback);
+                $task->dependency($package, $version);
+            }
+            elseif (strpos($package, 'drupal/lightning_') === 0)
+            {
+                $name = strstr($package, 'lightning_');
+                $callback = function ($range) use ($client, $name) {
+                    $release = $client->getLatestStableRelease($name, '8.x', $range);
+
+                    return $release ? "^$release" : $range;
+                };
+                $version = (new ComposerConstraint($constraint))->mapRanges($callback);
+                $task->dependency($package, $version);
             }
         }
 

--- a/Commands/RoboFile.php
+++ b/Commands/RoboFile.php
@@ -661,6 +661,8 @@ class RoboFile extends Tasks
 
         foreach ($composer['require'] as $package => $constraint)
         {
+            $callback = NULL;
+
             if ($package === 'drupal/core')
             {
                 $callback = function ($range) use ($client) {
@@ -668,8 +670,6 @@ class RoboFile extends Tasks
 
                     return $release ? "~$release" : $range;
                 };
-                $version = (new ComposerConstraint($constraint))->mapRanges($callback);
-                $task->dependency($package, $version);
             }
             elseif (strpos($package, 'drupal/lightning_') === 0)
             {
@@ -679,6 +679,9 @@ class RoboFile extends Tasks
 
                     return $release ? "^$release" : $range;
                 };
+            }
+
+            if ($callback) {
                 $version = (new ComposerConstraint($constraint))->mapRanges($callback);
                 $task->dependency($package, $version);
             }

--- a/Commands/RoboFile.php
+++ b/Commands/RoboFile.php
@@ -664,7 +664,7 @@ class RoboFile extends Tasks
             if ($package === 'drupal/core')
             {
                 $callback = function ($range) use ($client) {
-                    $release = $client->getLatestStableRelease('drupal', '8.x', $range);
+                    $release = $client->getLatestStableRelease('drupal', $range);
 
                     return $release ? "~$release" : $range;
                 };
@@ -675,7 +675,7 @@ class RoboFile extends Tasks
             {
                 $name = strstr($package, 'lightning_');
                 $callback = function ($range) use ($client, $name) {
-                    $release = $client->getLatestStableRelease($name, '8.x', $range);
+                    $release = $client->getLatestStableRelease($name, $range);
 
                     return $release ? "^$release" : $range;
                 };

--- a/tests/src/Unit/ReleaseHistoryClientTest.php
+++ b/tests/src/Unit/ReleaseHistoryClientTest.php
@@ -19,8 +19,6 @@ class ReleaseHistoryClientTest extends UnitTestCase {
    *
    * @param string $name
    *   The name of the Drupal project.
-   * @param string $api_version
-   *   The API compatibility version.
    * @param string $range
    *   The constraint range.
    * @param string $release_history
@@ -30,15 +28,15 @@ class ReleaseHistoryClientTest extends UnitTestCase {
    *
    * @dataProvider getLatestStableReleaseProvider
    */
-  public function testGetLatestStableRelease($name, $api_version, $range, $release_history, $expected) {
+  public function testGetLatestStableRelease($name, $range, $release_history, $expected) {
     $client = $this->getMockBuilder(Client::class)
       ->setMethods(['get'])
       ->getMock();
     $client->expects($this->once())
       ->method('get')
-      ->with("https://updates.drupal.org/release-history/$name/$api_version")
+      ->with("https://updates.drupal.org/release-history/$name/8.x")
       ->will($this->returnValue(new Response(200, [], $release_history)));
-    $result = (new ReleaseHistoryClient($client))->getLatestStableRelease($name, $api_version, $range);
+    $result = (new ReleaseHistoryClient($client))->getLatestStableRelease($name, $range);
     $this->assertSame($expected, $result);
   }
 
@@ -73,28 +71,24 @@ class ReleaseHistoryClientTest extends UnitTestCase {
     return [
       'drupal latest' => [
         'name' => 'drupal',
-        'api_version' => '8.x',
         'range' => '8.6.x-dev',
         'release_history' => $drupal_release_history,
         'expected' => '8.6.2',
       ],
       'drupal 8.5.x-dev' => [
         'name' => 'drupal',
-        'api_version' => '8.x',
         'range' => '8.5.x-dev',
         'release_history' => $drupal_release_history,
         'expected' => '8.5.8',
       ],
       'lightning_core latest' => [
         'name' => 'lightning_core',
-        'api_version' => '8.x',
         'range' => '3.x-dev',
         'release_history' => $lightning_core_release_history,
         'expected' => '3.2',
       ],
       'lightning_core 2.x-dev' => [
         'name' => 'lightning_core',
-        'api_version' => '8.x',
         'range' => '2.x-dev',
         'release_history' => $lightning_core_release_history,
         'expected' => '2.11',

--- a/tests/src/Unit/ReleaseHistoryClientTest.php
+++ b/tests/src/Unit/ReleaseHistoryClientTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\Tests\lightning_dev\Unit;
+
+use Acquia\Lightning\Commands\ReleaseHistoryClient;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests the ReleaseHistoryClient service.
+ *
+ * @group lightning_dev
+ */
+class ReleaseHistoryClientTest extends UnitTestCase {
+
+  /**
+   * Tests fetching the latest stable release.
+   *
+   * @param string $name
+   *   The name of the Drupal project.
+   * @param string $api_version
+   *   The API compatibility version.
+   * @param string $range
+   *   The constraint range.
+   * @param string $release_history
+   *   The mock response body.
+   * @param string $expected
+   *   The expected result.
+   *
+   * @dataProvider getLatestStableReleaseProvider
+   */
+  public function testGetLatestStableRelease($name, $api_version, $range, $release_history, $expected) {
+    $client = $this->getMockBuilder(Client::class)
+      ->setMethods(['get'])
+      ->getMock();
+    $client->expects($this->once())
+      ->method('get')
+      ->with("https://updates.drupal.org/release-history/$name/$api_version")
+      ->will($this->returnValue(new Response(200, [], $release_history)));
+    $result = (new ReleaseHistoryClient($client))->getLatestStableRelease($name, $api_version, $range);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for ::testGetLatestStableRelease().
+   *
+   * @return array
+   *   The test data.
+   */
+  public function getLatestStableReleaseProvider() {
+    $drupal_release_history = '
+      <project>
+        <releases>
+          <release><version>8.6.2</version></release>
+          <release><version>8.6.1</version></release>
+          <release><version>8.5.8</version></release>
+          <release><version>8.5.7</version></release>
+        </releases>
+      </project>
+    ';
+    $lightning_core_release_history = '
+      <project>
+        <releases>
+          <release><version>8.x-3.2</version></release>
+          <release><version>8.x-3.1</version></release>
+          <release><version>8.x-2.11</version></release>
+          <release><version>8.x-2.10</version></release>
+        </releases>
+      </project>
+    ';
+
+    return [
+      'drupal latest' => [
+        'name' => 'drupal',
+        'api_version' => '8.x',
+        'range' => '8.6.x-dev',
+        'release_history' => $drupal_release_history,
+        'expected' => '8.6.2',
+      ],
+      'drupal 8.5.x-dev' => [
+        'name' => 'drupal',
+        'api_version' => '8.x',
+        'range' => '8.5.x-dev',
+        'release_history' => $drupal_release_history,
+        'expected' => '8.5.8',
+      ],
+      'lightning_core latest' => [
+        'name' => 'lightning_core',
+        'api_version' => '8.x',
+        'range' => '3.x-dev',
+        'release_history' => $lightning_core_release_history,
+        'expected' => '3.2',
+      ],
+      'lightning_core 2.x-dev' => [
+        'name' => 'lightning_core',
+        'api_version' => '8.x',
+        'range' => '2.x-dev',
+        'release_history' => $lightning_core_release_history,
+        'expected' => '2.11',
+      ],
+    ];
+  }
+
+}

--- a/tests/src/Unit/ReleaseHistoryClientTest.php
+++ b/tests/src/Unit/ReleaseHistoryClientTest.php
@@ -29,14 +29,11 @@ class ReleaseHistoryClientTest extends UnitTestCase {
    * @dataProvider getLatestStableReleaseProvider
    */
   public function testGetLatestStableRelease($name, $range, $release_history, $expected) {
-    $client = $this->getMockBuilder(Client::class)
-      ->setMethods(['get'])
-      ->getMock();
-    $client->expects($this->once())
-      ->method('get')
-      ->with("https://updates.drupal.org/release-history/$name/8.x")
-      ->will($this->returnValue(new Response(200, [], $release_history)));
-    $result = (new ReleaseHistoryClient($client))->getLatestStableRelease($name, $range);
+    $client = $this->prophesize(Client::class);
+    $client->get("https://updates.drupal.org/release-history/$name/8.x")
+      ->shouldBeCalledOnce()
+      ->willReturn(new Response(200, [], $release_history));
+    $result = (new ReleaseHistoryClient($client->reveal()))->getLatestStableRelease($name, $range);
     $this->assertSame($expected, $result);
   }
 


### PR DESCRIPTION
I used https://updates.drupal.org to parse release information.
The latest stable release version is decided by comparing the release versions to the current composer constraint.
