### PR TITLE
Add the base_url to the site-install command

### DIFF
--- a/Commands/RoboFile.php
+++ b/Commands/RoboFile.php
@@ -113,6 +113,11 @@ class RoboFile extends Tasks
   ],
 ];
 END;
+        
+        $uri = $base_url;
+        if ($uri == NULL) {
+          $uri = 'http://default';
+        }
 
         $tasks = $this->collectionBuilder()
             ->addTask(
@@ -121,6 +126,7 @@ END;
                     ->option('yes')
                     ->option('account-pass', 'admin')
                     ->option('db-url', $db_url)
+                    ->option('uri', $uri)
             )
             ->addTask(
                 $this->taskFilesystemStack()


### PR DESCRIPTION
I noticed when running install the uri is `http://default` instead of the provided url. Not sure if this is by design, but it stands to reason the site install and other commands should use the url if provided.